### PR TITLE
update documentation to glubert 0.2.0

### DIFF
--- a/documentation/themes/gluebert/package.json
+++ b/documentation/themes/gluebert/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "animejs": "^2.0.2",
-    "gluebert": "0.1.1",
+    "gluebert": "0.2.0",
     "prismjs": "^1.7.0",
     "twig": "^1.10.5"
   }


### PR DESCRIPTION
## Description

Update Gluebert.js version to v0.2.0 for documentation.

## Checklist

- [x] I have updated the documentation
- [ ] I have included tests
- [x] I have read and understood the MIT license of this repository and confirm that there is no protected code pushed to this repository 

## Breaking Change

- [x] No, this is not a breaking change.
- [ ] This is a breaking change:
    <please explain what and why it actually break>

## Related Issues

- Data observer does not work in the documentation on https://gluebert.com